### PR TITLE
Update data types to conform to C standard types

### DIFF
--- a/bmp280.h
+++ b/bmp280.h
@@ -275,13 +275,13 @@ define the MACHINE_32_BIT*/
 /*signed integer types*/
 typedef	signed char  s8;/**< used for signed 8bit */
 typedef	signed short int s16;/**< used for signed 16bit */
-typedef	signed int s32;/**< used for signed 32bit */
+typedef	signed long s32;/**< used for signed 32bit */
 typedef	signed long long int s64;/**< used for signed 64bit */
 
 /*unsigned integer types*/
 typedef	unsigned char u8;/**< used for unsigned 8bit */
 typedef	unsigned short int u16;/**< used for unsigned 16bit */
-typedef	unsigned int u32;/**< used for unsigned 32bit */
+typedef	unsigned long u32;/**< used for unsigned 32bit */
 typedef	unsigned long long int u64;/**< used for unsigned 64bit */
 #define BMP280_64BITSUPPORT_PRESENT
 


### PR DESCRIPTION
The data types defined in bmp280.h (lines 275-285) will not work properly on a 16-bit architecture. The "int" datatype is architecture specific and may result in either a 16-bit or 32-bit quantity. On a 16-bit architecture, an int is only 16 bits but is being used in bmp280.h to represent a 32-bit quantity.