### PR TITLE
Better integration as submodule

### DIFF
--- a/bmp280.c
+++ b/bmp280.c
@@ -83,7 +83,7 @@ static struct bmp280_t *p_bmp280; /**< pointer to BMP280 */
 BMP280_RETURN_FUNCTION_TYPE bmp280_init(struct bmp280_t *bmp280)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	u8 v_chip_id_read_count = BMP280_CHIP_ID_READ_COUNT;
 
@@ -138,7 +138,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_read_uncomp_temperature(
 		s32 *v_uncomp_temperature_s32)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	/* Array holding the MSB and LSb value
 	 a_data_u8r[0] - Temperature MSB
 	 a_data_u8r[1] - Temperature LSB
@@ -234,7 +234,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_read_uncomp_pressure(
 		s32 *v_uncomp_pressure_s32)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	/* Array holding the MSB and LSb value
 	 a_data_u8[0] - Pressure MSB
 	 a_data_u8[1] - Pressure LSB
@@ -363,7 +363,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_read_uncomp_pressure_temperature(
 		s32 *v_uncomp_pressure_s32, s32 *v_uncomp_temperature_s32)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	/* Array holding the temperature and pressure data
 	 a_data_u8[0] - Pressure MSB
 	 a_data_u8[1] - Pressure LSB
@@ -424,7 +424,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_read_pressure_temperature(
 		u32 *v_pressure_u32, s32 *v_temperature_s32)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	s32 v_uncomp_pressure_s32 = BMP280_INIT_VALUE;
 	s32 v_uncomp_temperature_s32 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
@@ -471,7 +471,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_read_pressure_temperature(
 BMP280_RETURN_FUNCTION_TYPE bmp280_get_calib_param(void)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 a_data_u8[BMP280_CALIB_DATA_SIZE] = {BMP280_INIT_VALUE,
 			BMP280_INIT_VALUE, BMP280_INIT_VALUE, BMP280_INIT_VALUE,
 			BMP280_INIT_VALUE, BMP280_INIT_VALUE, BMP280_INIT_VALUE,
@@ -581,7 +581,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_get_calib_param(void)
 BMP280_RETURN_FUNCTION_TYPE bmp280_get_oversamp_temperature(u8 *v_value_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -626,7 +626,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_get_oversamp_temperature(u8 *v_value_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_set_oversamp_temperature(u8 v_value_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -635,7 +635,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_oversamp_temperature(u8 v_value_u8)
 		com_rslt = p_bmp280->BMP280_BUS_READ_FUNC(p_bmp280->dev_addr,
 				BMP280_CTRL_MEAS_REG_OVERSAMP_TEMPERATURE__REG,
 				&v_data_u8, BMP280_GEN_READ_WRITE_DATA_LENGTH);
-		if (com_rslt == SUCCESS) {
+		if (com_rslt == BMP_SUCCESS) {
 			/* write over sampling*/
 			v_data_u8 = BMP280_SET_BITSLICE(v_data_u8,
 				BMP280_CTRL_MEAS_REG_OVERSAMP_TEMPERATURE,
@@ -678,7 +678,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_oversamp_temperature(u8 v_value_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_get_oversamp_pressure(u8 *v_value_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -723,7 +723,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_get_oversamp_pressure(u8 *v_value_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_set_oversamp_pressure(u8 v_value_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -732,7 +732,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_oversamp_pressure(u8 v_value_u8)
 		com_rslt = p_bmp280->BMP280_BUS_READ_FUNC(p_bmp280->dev_addr,
 				BMP280_CTRL_MEAS_REG_OVERSAMP_PRESSURE__REG,
 				&v_data_u8, BMP280_GEN_READ_WRITE_DATA_LENGTH);
-		if (com_rslt == SUCCESS) {
+		if (com_rslt == BMP_SUCCESS) {
 			/* write pressure over sampling */
 			v_data_u8 = BMP280_SET_BITSLICE(v_data_u8,
 					BMP280_CTRL_MEAS_REG_OVERSAMP_PRESSURE,
@@ -770,7 +770,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_oversamp_pressure(u8 v_value_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_get_power_mode(u8 *v_power_mode_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_mode_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -807,7 +807,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_get_power_mode(u8 *v_power_mode_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_set_power_mode(u8 v_power_mode_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_mode_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -850,7 +850,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_power_mode(u8 v_power_mode_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_set_soft_rst(void)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_SOFT_RESET_CODE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -886,7 +886,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_soft_rst(void)
 BMP280_RETURN_FUNCTION_TYPE bmp280_get_spi3(u8 *v_enable_disable_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -923,7 +923,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_get_spi3(u8 *v_enable_disable_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_set_spi3(u8 v_enable_disable_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -932,7 +932,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_spi3(u8 v_enable_disable_u8)
 		com_rslt = p_bmp280->BMP280_BUS_READ_FUNC(p_bmp280->dev_addr,
 				BMP280_CONFIG_REG_SPI3_ENABLE__REG, &v_data_u8,
 				BMP280_GEN_READ_WRITE_DATA_LENGTH);
-		if (com_rslt == SUCCESS) {
+		if (com_rslt == BMP_SUCCESS) {
 			v_data_u8 = BMP280_SET_BITSLICE(v_data_u8,
 					BMP280_CONFIG_REG_SPI3_ENABLE,
 					v_enable_disable_u8);
@@ -969,7 +969,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_spi3(u8 v_enable_disable_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_get_filter(u8 *v_value_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -1007,7 +1007,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_get_filter(u8 *v_value_u8)
  */
 BMP280_RETURN_FUNCTION_TYPE bmp280_set_filter(u8 v_value_u8)
 {
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = SUCCESS;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_SUCCESS;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -1017,7 +1017,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_filter(u8 v_value_u8)
 		com_rslt = p_bmp280->BMP280_BUS_READ_FUNC(p_bmp280->dev_addr,
 				BMP280_CONFIG_REG_FILTER__REG, &v_data_u8,
 				BMP280_GEN_READ_WRITE_DATA_LENGTH);
-		if (com_rslt == SUCCESS) {
+		if (com_rslt == BMP_SUCCESS) {
 			v_data_u8 = BMP280_SET_BITSLICE(v_data_u8,
 					BMP280_CONFIG_REG_FILTER, v_value_u8);
 			com_rslt += p_bmp280->BMP280_BUS_WRITE_FUNC(
@@ -1056,7 +1056,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_filter(u8 v_value_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_get_standby_durn(u8 *v_standby_durn_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -1109,7 +1109,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_get_standby_durn(u8 *v_standby_durn_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_set_standby_durn(u8 v_standby_durn_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -1119,7 +1119,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_standby_durn(u8 v_standby_durn_u8)
 		com_rslt = p_bmp280->BMP280_BUS_READ_FUNC(p_bmp280->dev_addr,
 				BMP280_CONFIG_REG_STANDBY_DURN__REG, &v_data_u8,
 				BMP280_GEN_READ_WRITE_DATA_LENGTH);
-		if (com_rslt == SUCCESS) {
+		if (com_rslt == BMP_SUCCESS) {
 			v_data_u8 = BMP280_SET_BITSLICE(v_data_u8,
 					BMP280_CONFIG_REG_STANDBY_DURN,
 					v_standby_durn_u8);
@@ -1155,7 +1155,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_standby_durn(u8 v_standby_durn_u8)
 BMP280_RETURN_FUNCTION_TYPE bmp280_set_work_mode(u8 v_work_mode_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
@@ -1166,7 +1166,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_set_work_mode(u8 v_work_mode_u8)
 				p_bmp280->dev_addr,
 				BMP280_CTRL_MEAS_REG, &v_data_u8,
 				BMP280_GEN_READ_WRITE_DATA_LENGTH);
-		if (com_rslt == SUCCESS) {
+		if (com_rslt == BMP_SUCCESS) {
 			switch (v_work_mode_u8) {
 			/* write work mode*/
 			case BMP280_ULTRA_LOW_POWER_MODE:
@@ -1235,7 +1235,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_get_forced_uncomp_pressure_temperature(
 		s32 *v_uncomp_pressure_s32, s32 *v_uncomp_temperature_s32)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	u8 v_data_u8 = BMP280_INIT_VALUE;
 	u8 v_waittime_u8 = BMP280_INIT_VALUE;
 	/* check the p_bmp280 structure pointer as NULL*/
@@ -1280,7 +1280,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_write_register(u8 v_addr_u8, u8 *v_data_u8,
 		u8 v_len_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
 		com_rslt = E_BMP280_NULL_PTR;
@@ -1311,7 +1311,7 @@ BMP280_RETURN_FUNCTION_TYPE bmp280_read_register(u8 v_addr_u8, u8 *v_data_u8,
 		u8 v_len_u8)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = ERROR;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_ERROR;
 	/* check the p_bmp280 structure pointer as NULL*/
 	if (p_bmp280 == BMP280_NULL) {
 		com_rslt = E_BMP280_NULL_PTR;
@@ -1493,7 +1493,7 @@ u32 bmp280_compensate_pressure_int64(s32 v_uncomp_pressure_s32)
 BMP280_RETURN_FUNCTION_TYPE bmp280_compute_wait_time(u8 *v_delaytime_u8r)
 {
 	/* variable used to return communication result*/
-	BMP280_RETURN_FUNCTION_TYPE com_rslt = SUCCESS;
+	BMP280_RETURN_FUNCTION_TYPE com_rslt = BMP_SUCCESS;
 
 	*v_delaytime_u8r = (T_INIT_MAX + T_MEASURE_PER_OSRS_MAX * (((1
 			<< p_bmp280->oversamp_temperature)

--- a/bmp280.h
+++ b/bmp280.h
@@ -476,11 +476,11 @@ BMP280_BUS_RD_PARAM_TYPE to function calls used inside the API
 /************************************************/
 /**\name	ERROR CODES      */
 /************************************************/
-#define	SUCCESS			((u8)0)
+#define	BMP_SUCCESS			((u8)0)
 #define E_BMP280_NULL_PTR         ((s8)-127)
 #define E_BMP280_COMM_RES         ((s8)-1)
 #define E_BMP280_OUT_OF_RANGE     ((s8)-2)
-#define ERROR                     ((s8)-1)
+#define BMP_ERROR                     ((s8)-1)
 /************************************************/
 /**\name	CHIP ID DEFINITION       */
 /***********************************************/

--- a/bmp280_support.c
+++ b/bmp280_support.c
@@ -150,7 +150,7 @@ s32 bmp280_data_readout_template(void)
 	u32 v_actual_press_combined_u32 = BMP280_INIT_VALUE;
 
 	/* result of communication results*/
-	s32 com_rslt = ERROR;
+	s32 com_rslt = BMP_ERROR;
 /*********************** START INITIALIZATION ************************/
   /*	Based on the user need configure I2C or SPI interface.
    *	It is example code to explain how to use the bmp280 API*/
@@ -320,7 +320,7 @@ s8 SPI_routine(void) {
  *		which is written in the register
  *	\param cnt : The no of bytes of data to be written
  */
-s8  BMP280_I2C_bus_write(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
+__weak s8  BMP280_I2C_bus_write(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
 {
 	s32 iError = BMP280_INIT_VALUE;
 	u8 array[I2C_BUFFER_LEN];
@@ -354,7 +354,7 @@ s8  BMP280_I2C_bus_write(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
  *	\param reg_data : This is the data read from the sensor, which is held in an array
  *	\param cnt : The no of data to be read
  */
-s8  BMP280_I2C_bus_read(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
+__weak s8  BMP280_I2C_bus_read(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
 {
 	s32 iError = BMP280_INIT_VALUE;
 	u8 array[I2C_BUFFER_LEN] = {BMP280_INIT_VALUE};
@@ -382,7 +382,7 @@ s8  BMP280_I2C_bus_read(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
  *	\param reg_data : This is the data read from the sensor, which is held in an array
  *	\param cnt : The no of data to be read
  */
-s8  BMP280_SPI_bus_read(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
+__weak s8  BMP280_SPI_bus_read(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
 {
 	s32 iError=BMP280_INIT_VALUE;
 	u8 array[SPI_BUFFER_LEN]={BUFFER_LENGTH};
@@ -422,7 +422,7 @@ s8  BMP280_SPI_bus_read(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
  *		which is written in the register
  *	\param cnt : The no of bytes of data to be written
  */
-s8  BMP280_SPI_bus_write(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
+__weak s8  BMP280_SPI_bus_write(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
 {
 	s32 iError = BMP280_INIT_VALUE;
 	u8 array[SPI_BUFFER_LEN * BMP280_ADDRESS_INDEX];
@@ -450,7 +450,7 @@ s8  BMP280_SPI_bus_write(u8 dev_addr, u8 reg_addr, u8 *reg_data, u8 cnt)
 /*	Brief : The delay routine
  *	\param : delay in ms
 */
-void  BMP280_delay_msek(u32 msek)
+__weak void  BMP280_delay_msek(u32 msek)
 {
 	/*Here you can write your own delay routine*/
 }


### PR DESCRIPTION
SUCCESS and ERROR are too generic and may conflict with other libraries, renamed to BMP_SUCCESS and BMP_ERROR
Added __weak to bmp280_support functions so they can be overridden when this library is imported as submodule