### PR TITLE
init: add 10ms to let sensor stable after rebooting

### DIFF
--- a/bmp280.c
+++ b/bmp280.c
@@ -251,6 +251,8 @@ int8_t bmp280_init(struct bmp280_dev *dev)
                 rslt = bmp280_soft_reset(dev);
                 if (rslt == BMP280_OK)
                 {
+                    /* Start-up wait */
+                    dev->delay_ms(10);
                     rslt = get_calib_param(dev);
                 }
                 break;


### PR DESCRIPTION
Right after perform soft reset on BMP280, the driver should wait a bit before calling get_calib_param(). Otherwise, it would read all 0xff or 0x00 over I2C.
In datasheet, it requires about 2ms (max), but I tried 2ms or 5ms on my ESP32 (80MHz, vTaskDelay) without sucess. I put 10ms instead.